### PR TITLE
NoAudio resets after newroundloaded

### DIFF
--- a/fetchFromFreeSound.js
+++ b/fetchFromFreeSound.js
@@ -242,7 +242,9 @@ function submitAnswer(answer) {
   }
   //reset passCount and NoMoreAudio window
   passCount = 0
-  document.getElementById('noAudio').classList.toggle('hide');
+  if (!document.getElementById('noAudio').classList.contains('hide')){
+    document.getElementById('noAudio').classList.toggle('hide');
+  }
   const flagsElements = document.getElementsByClassName("flag");
   for (let i = 0; i < flagsElements.length; i++) {
     flagsElements[i].removeEventListener('click', checkAnswer);


### PR DESCRIPTION
NoAudio only toggles if hide isn't in classlist when loading new round.